### PR TITLE
Add macOS/clang support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
   set(IntelComp true )
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU*")
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU*" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang*")
   set(GNUComp true )
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "pgc*")
   set(PGIComp true )


### PR DESCRIPTION
Adding macOS/clang support *for the third time to the same CMakeLists.txt*. Note that this is the wrong branch (ufs_release_v1.0). A similar PR will be made for the "correct" branch release/ufs_release_v1.0 in a minute (https://github.com/kgerheiser/UFS_UTILS/pull/2).

Note that even though .gitmodules in @kgerheiser's NCEPLIBS umbrella repo says branch=release/ufs_release_v1.0, the hash it points to at the moment (prior to these commits) is in the ufs_release_1.0 branch (i.e. without the release/ prefix).

Can we just delete the ufs_release_1.0 branches w/o the release/ prefix in your fork and in the authoritative repository?